### PR TITLE
version upgrade for hub

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'facebook_ads_creative_history'
-version: '0.2.0'
+version: '0.2.1'
 config-version: 2
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'facebook_ads_source_integration_tests'
-version: '0.2.0'
+version: '0.2.1'
 profile: 'integration_tests'
 config-version: 2
 


### PR DESCRIPTION
This PR includes the following updates:
- version upgrade to v0.2.1 to kick off dbt hub PR

FYI no additional changes will need to be made in other packages as the [dbt_facebook_ads](https://github.com/fivetran/dbt_facebook_ads/blob/master/packages.yml) `packages.yml` references the below range for this package:
```yml
packages:
  - package: fivetran/facebook_ads_creative_history
    version: [">=0.2.0","<0.3.0"] 
```